### PR TITLE
Serve pages via docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Hi and welcome to my blog. 👋🏼
 
-I'm in the process of making this a website so that you can reference stable URLs outside of GitHub :)
+The posts in this repository are published automatically with **GitHub Pages**. Just browse to the Pages URL (usually `https://<username>.github.io/<repo>/`) to read them online.
 
-Please let me know your throughts in the Discussions tab!
+All the Markdown files under `docs/` become pages on the site. Edit them directly and push to Git to update the website.
+
+Please let me know your thoughts in the Discussions tab!

--- a/docs/age-of-majority.md
+++ b/docs/age-of-majority.md
@@ -1,0 +1,13 @@
+We need to very seriously examine the real-world implications of the age of majority[^r] in the context of how it prevents our youth from achieving economic independence after requisite primary school.
+
+_See, e.g._ restrictions on banking services, brokerage services, and "lottery" services.
+
+obvs introduce the mcdonalds (1yr_ limelight horizon argument
+
+
+the alcohol bit should very lightly implicate
+https://www.reddit.com/r/LinkinPark/s/GiRk5FDqGN
+in a most respectable forelight of childhood life choices v. work choices (presuming not a deadly factory etc)
+
+
+[^r]: _See, e.g._ "Romeo and Juliet" laws, underage/child labor exploitation, and poisoning yourself with [piss](https://www.youtube.com/watch?v=UCekG0O21wQ).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# My Blog
+
+Welcome! This site is built directly from the Markdown files in this repository.
+
+## Posts
+- [Age of Majority](age-of-majority.md)
+- [Liquidity is its Own Incentive](liquidity-as-own-incentive.md)
+- [How "Maker v. Manager" Time Scheduling Reveals Deep Organizational Flaws](workers-v-bureaucrats.md)

--- a/docs/liquidity-as-own-incentive.md
+++ b/docs/liquidity-as-own-incentive.md
@@ -1,0 +1,12 @@
+# Liquidity is its Own Incentive
+
+[vid from merridian prob]
+
+> With the development of the Soroban smart contracts platform, ecosystem developers can create AMM protocols that use smart contracts to allow trustless, _incentivized_ participation in liquidity provision
+>
+> &mdash;[SDF](https://stellar.org/learn/swap-functionality-and-amms)
+
+(emphasis added)
+
+_Compare_ with the Madoff exemption
+_See_ application of swe in [shitdle](https://www.reddit.com/r/Superstonk/comments/pjf2vx/hedgies_r_fuk/) at https://github.com/MichaelxhJiang/stellar-tip

--- a/docs/workers-v-bureaucrats.md
+++ b/docs/workers-v-bureaucrats.md
@@ -1,0 +1,40 @@
+# How "Maker v. Manager" Time Scheduling Reveals Deep Organizational Flaws
+
+Some time ago, I read about [maker v. manager](HREF_SRC) time management. Talk about a sentence with "manage" and "time" in abundance. That'll be a theme of this post, as I've come to recognize how this differentiation only propogates inefficincies, biased power dynamics, adn frankly personal _anxiety_.
+
+There's  a saying that you can't "learn" to become a CEO.[^3-srcs-ceo] Indeed, most organization heads get poached from other (similar) businesses.[^3-ceo-cngs] They say it's because you either "know it" or "you don't" when it comes to executive decision making.
+
+Indeed, public companies often share board members, and their tancit sitting approval can oft make or break a San Francisco startup. In contemplating why that might be, I realized that these activites fundamentally shift time, money, and energy awya from _real work_. Rather, they prioritze a dystopian centralization scheme that keeps the rick and powerful at the top, while mere workers [have their pensions stolen](SRC_BOING).
+
+## The Concept
+
+As XYZ)JOURNAL_NAME_OR_ORS_IDK points out, there are two kinds of "time" in centralized organizations. "Marker time" is all-encompassing, unstructured, and entirely your choice. It's just a large block of your own space to do what you think is best.[^disney]
+
+The beaty of this special time? It lets your creative juices start flowing. It empowers you to become tuly inspired. And, as originally explained, it "_____leads to your best work___."
+
+If that makes sense to you, then keep reading. But if not, I might take pause and consider when you really felt you were doing your "best wprk." Was it in a management meeting clicking through a powerpoint, or was it sometime when your own ideas came to light in the act of creating some exciting work-product?
+
+### Manager's Time
+
+"Managers time" is explicit, scheduled, and directive. You do this thing, at this time, with these people, etc. Indeed, I commonly find that the manager has back-to-back meetings to "maximize their producitvity."
+
+With manager's time, there is no moment to reflect, no space to think, and no chance to celebrate your daily accomplishments. Gratitude, contemplation, and serenity oft get thrown to the wayside. And no, your schedule 15-minute breaks or "personal time" calendar inputs don't count.
+
+Manager's time emmerged in the _1900s_ when central factories took over as a dominant means of production.[^single-src-should-suffice] While it might be the de-facto planning approach for today's largest organizations, I doubt the practice helps people achieve their best results. Indeed, when Jobs introduced the idea that you might have your own computer that's just as capable as a central terminal,
+
+
+sotry of conflcts 
+
+transparency impications re kyc pricing
+
+quandary of building something to profit one person v. benefit the actual users
+
+
+decentralization and distribution implications as wrap up
+
+
+[^disney]: Or what you're assigned to do, as the case may be. But generally the concept applies when it's a vague overarching item. More along the lines of "work on this movie scene's XYZ thing" than "complete the XYZ thing in this specific way using these specific tools with these particular people."
+[^others]: 
+  - been working for circa last 10 hours writing this, and it's the "random thoughts" and permission to act on them that lead to such innovations
+  - idea of having a (shared) [goal(s)]() in midn as the guiding princniples of individual midns rather than explciit centrally-planned work items
+  - use of meetings in the light of teambuilding relationsships, not a means to best source real development (when ppl might not b abl to attend re


### PR DESCRIPTION
## Summary
- remove Python site generator and old HTML outputs
- add `docs/` directory with Markdown copies of draft posts
- update README with GitHub Pages deployment instructions

## Testing
- `ls docs`


------
https://chatgpt.com/codex/tasks/task_e_685e99f845208330be0b5825a322aee6